### PR TITLE
Update stanfit.R

### DIFF
--- a/fourmarker/stanfit.R
+++ b/fourmarker/stanfit.R
@@ -14,12 +14,12 @@ if (any(simdata$id != match(simdata$id, uid))) stop("id is not sequential")
 stan.list <- list(id = simdata$id, y= simdata$y, 
                outcome= as.numeric(simdata$outcome),
                age = simdata$age,
-               x = cbind(simdata$male, simdata$apoe, simdata$apoemis,
+               x = cbind(simdata$male, simdata$apoepos, simdata$apoemiss,
                          simdata$educ-16),
                adrc = simdata$adrc,
                N = nrow(simdata),  # number of obs
                M = length(uid),    # number of unique subjects
-               P = 3,              # number of covariates
+               P = 4,              # number of covariates
                dft = 10            # df for the t distribution
 )
 


### PR DESCRIPTION
 I reviewed the “fourmarkers” repository and found a couple typos:

Line 17:                 x = cbind(simdata$male, simdata$apoepos, simdata$apoemiss,
Line 22:  P = 4  (not 3)
