### PR TITLE
Update stanfit.R

### DIFF
--- a/fourmarker/stanfit.R
+++ b/fourmarker/stanfit.R
@@ -46,6 +46,7 @@ fit4<- stan("aft4.stan",
             cores = nchains,
             pars = c("alpha", "B", "beta", "sigma", "Omega", "atau", 
                      "adrc_shift")
+            seed = 1402  ## for reproducible initials not specified by init.list
             )
 
 # save(fit4, "fit4save.rda")


### PR DESCRIPTION
This is less of bug fix and more of a 'best practice'.  We need to set the seed within the call of stan.  Any parameters for which initial values were not specified will receive a randomly generated initial value.  Using R's set.seed function to set the seed for Stan will not work per the documentation.